### PR TITLE
JBufford Modifications to TPLck

### DIFF
--- a/R/TPL.R
+++ b/R/TPL.R
@@ -1,5 +1,5 @@
 TPL <-
-function(splist, genus=NULL, species=NULL, infrasp=NULL, infra=TRUE, abbrev=TRUE, corr=TRUE, diffchar=2, max.distance=1, version="1.1", encoding="UTF-8", file="") {
+function(splist, id=NULL, genus=NULL, species=NULL, infrasp=NULL, infra=TRUE, abbrev=TRUE, corr=TRUE, diffchar=2, max.distance=1, version="1.1", encoding="UTF-8", file="") {
 splist2 <- NULL
 try(splist2 <- splist, silent=TRUE)
 if(!is.null(splist2) && (!is.null(genus) || !is.null(species) || !is.null(infrasp))) {
@@ -36,17 +36,23 @@ splist <- paste(genus, species)
 #splist <- gsub("   ", " ", splist, fixed=TRUE)
 #splist <- gsub("  ", " ", splist, fixed=TRUE)
 #splist <- gsub("_", "", splist, fixed=TRUE)
-#for(i in 1:length(splist)) {splist[i] <- ifelse(substr(splist[i], 1, 1)==" ", substr(splist[i], 2, nchar(splist[i])), splist[i])} 
+#for(i in 1:length(splist)) {splist[i] <- ifelse(substr(splist[i], 1, 1)==" ", substr(splist[i], 2, nchar(splist[i])), splist[i])}
 
 
 TPLck2 <- function(d) {
-TPLck(sp=d, corr=corr, diffchar=diffchar, max.distance=max.distance, infra=infra, abbrev=abbrev, version=version, encoding=encoding)
+  sp <- strsplit(d, ":")[[1]][1]
+  id <- strsplit(d, ":")[[1]][2]
+TPLck(sp=sp, corr=corr, diffchar=diffchar, max.distance=max.distance, infra=infra, abbrev=abbrev, version=version, encoding=encoding, id = id)
 }
-results <- do.call("rbind", lapply(splist, TPLck2))
+results <- do.call("rbind", lapply(paste(splist, id, sep=":"), TPLck2))
 #results$Infraspecific <- ifelse(results$Infraspecific=="NA", "", as.character(results$Infraspecific))
 #results <- data.frame(results[,1:2], Abbrev=as.character(abbr), results[,-c(1:2)])
 if(infra==FALSE) {
-results <- results[,-c(4,13)]
+results <- results[,-which(names(results) %in% c('Infraspecific','New.Infraspecific',
+                                                 'New.Abbrev'))]
+}
+if(sum(is.na(results$UserID))==nrow(results)) {
+  results <- results[,-which(names(results)=="UserID")]
 }
 if(nchar(file)>0) {
 write.csv(results, file=file, row.names=F)

--- a/R/TPLck.R
+++ b/R/TPLck.R
@@ -166,7 +166,7 @@ else if (z > 0) {
 
         syn <- at[pmatch(az, at)] #Looks for line that matches to current name
         syn <- unlist(strsplit(unlist(strsplit(syn, split = ">")), "<"))
-        newgen[[i]] <- syn[13]
+        newgen[[i]] <- ifelse(syn[13]=='×', paste(syn[13], syn[17], sep=""), syn[13])
       }
 
       newgen <- newgen[samp]

--- a/R/TPLck.R
+++ b/R/TPLck.R
@@ -285,10 +285,20 @@ if (length(unique(paste(table.sp$Genus, table.sp$Species))) > 1) {
   return(notfound(id, Genus, Species, Abbrev, Infraspecific, version,
                   New.Hybrid.marker))
   #If still returning entire genus list, or corr=F, match was not found
-  #   could potentially alter code here to search for 2nd best match?
 }
 
+## If Direct Match or After Fuzzy Matching ##
+
 if (length(unique(paste(table.sp$Genus, table.sp$Species))) == 1) {
+
+  #If genus name matches to only one entry in TPL, it is automatically returned,
+  #   regardless of whether it matches the submitted specific epithet
+  #   Here, will reject if it does not match the specific epithet
+  if(!species %in% table.sp$Species & !marker) {
+    return(notfound(id, Genus, Species, Abbrev, Infraspecific, version,
+                    New.Hybrid.marker))
+  }
+
 grep1 <- grep(infrasp, table.sp$Infraspecific.epithet, value=TRUE)
 ngrep <- nchar(grep1)
 

--- a/R/TPLck.R
+++ b/R/TPLck.R
@@ -149,7 +149,7 @@ else if (z > 0) {
         table.sp <- table.sp[table.sp$Confidence.level=="H",]
       }
 
-      samp <- sample(1:nrow(table.sp), min(ceiling(0.25*nrow(table.sp)), 15))
+      samp <- sample(1:nrow(table.sp), min(ceiling(0.5*nrow(table.sp)), 15))
       newgen <- vector()
 
       for(i in samp){
@@ -282,7 +282,14 @@ cck.infra <- agrep(infrasp, table.sp$Infraspecific.epithet, value=TRUE, max.dist
 ddf.infra <- abs(nchar(cck.infra) - nchar(infrasp))
 if(length(cck.infra) > 0) {
 cck.infra <- cck.infra[ddf.infra==min(ddf.infra)]
-ddf.infra <- abs(nchar(cck.infra) - nchar(infrasp))
+}
+#Remove spelling variants (to prevent unnecessary "multi" matches)
+if(length(cck.infra) > 0 && "Spelling variant" %in% table.sp[,12] &&
+     sum(table.sp[,12]=="Spelling variant") < length(cck.infra)){
+  cck.infra <-
+    cck.infra[!cck.infra %in% table.sp[table.sp[,12] %in% 'Spelling variant',
+                                       'Infraspecific.epithet']]
+  #table.sp[,12] is Nomenclatural.status.from.original.data.source
 }
 levs <- length(unique(cck.infra))
 if(length(cck.infra) > 0 && levs == 1) {

--- a/R/TPLck.R
+++ b/R/TPLck.R
@@ -130,7 +130,8 @@ else if (z > 0) {
       Plant.Name.Index <- TRUE
       Taxonomic.status <- table.sp$Taxonomic.status.in.TPL[1]
       Family <- table.sp$Family[1]
-      New.Genus <- table.sp$Genus[1]
+      New.Genus <- if('' %in% table.sp$Genus.hybrid.marker) {table.sp$Genus[1]} else {
+        paste(table.sp$Genus.hybrid.marker[1], table.sp$Genus[1], sep='')}
       New.Hybrid.marker <- ''
       New.Species <- ''
       New.Abbrev <- ""
@@ -170,7 +171,7 @@ else if (z > 0) {
 
         syn <- at[pmatch(az, at)] #Looks for line that matches to current name
         syn <- unlist(strsplit(unlist(strsplit(syn, split = ">")), "<"))
-        newgen[[i]] <- ifelse(syn[13]=='×', paste(syn[13], syn[17], sep=""), syn[13])
+        newgen[[i]] <- ifelse(syn[13]=='×', syn[17], syn[13])
       }
 
       newgen <- newgen[samp]
@@ -212,7 +213,8 @@ else if (z > 0) {
       Plant.Name.Index <- TRUE
       Taxonomic.status <- 'Synonym'
       Family <- table.sp$Family[1]
-      New.Genus <- ng
+      New.Genus <- if('' %in% table.sp$Genus.hybrid.marker) {table.sp$Genus[1]} else {
+        paste(table.sp$Genus.hybrid.marker[1], table.sp$Genus[1], sep='')}
       New.Hybrid.marker <- ''
       New.Species <- ''
       New.Abbrev <- ""
@@ -367,7 +369,8 @@ if(nrow(table.sp)>1){
 Plant.Name.Index <- TRUE
 Taxonomic.status <- table.sp$Taxonomic.status.in.TPL[1]
 Family <- table.sp$Family[1]
-New.Genus <- table.sp$Genus[1]
+New.Genus <- if('' %in% table.sp$Genus.hybrid.marker) {table.sp$Genus[1]} else {
+  paste(table.sp$Genus.hybrid.marker[1], table.sp$Genus[1], sep='')}
 New.Hybrid.marker <- table.sp$Species.hybrid.marker[1]
 New.Species <- table.sp$Species[1]
 if (infra == T && length(grep(infrasp, table.sp$Infraspecific.epithet))>0) {
@@ -435,7 +438,7 @@ n <- pmatch(az, at) #Looks for line that matches to current name
 nsen <- at[n]
 nsen <- unlist(strsplit(unlist(strsplit(nsen, split=">")), "<"))
 if (version=="1.1") {
-searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[13],"+",ifelse(nsen[17]=="×", nsen[21], nsen[17]), "&csv=true", sep="")
+searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",ifelse(nsen[13] =="×",nsen[17],nsen[13]),"+",ifelse("×" %in% nsen[c(13,17)], nsen[21],nsen[17]), "&csv=true", sep="")
 } else
 if (version=="1.0") {
 searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[11],"+",ifelse(nsen[15]=="×", nsen[19], nsen[15]), "&csv=true", sep="")
@@ -443,10 +446,10 @@ searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[1
 kup <- length(grep("var.", nsen)) + length(grep("subsp.", nsen))
 if(infra==T && kup > 0) {
 if (version=="1.1") {
-infrasp <- ifelse(nsen[17]=="×", nsen[29], nsen[25])
+infrasp <- ifelse("×" %in% nsen[c(13,17)], nsen[29], nsen[25])
 } else
 if (version=="1.0") {
-infrasp <- ifelse(nsen[15]=="×", nsen[27], nsen[23])
+infrasp <- ifelse(nsen[15] == "×", nsen[27], nsen[23])
 }
 } else
 if(kup == 0) {
@@ -490,7 +493,8 @@ if(nrow(table.sp)>1){
 #If still mutl entries, take first one
 Plant.Name.Index <- TRUE
 Family <- table.sp$Family[1]
-New.Genus <- table.sp$Genus[1]
+New.Genus <- if('' %in% table.sp$Genus.hybrid.marker) {table.sp$Genus[1]} else {
+  paste(table.sp$Genus.hybrid.marker[1], table.sp$Genus[1], sep='')}
 New.Hybrid.marker <- table.sp$Species.hybrid.marker[1]
 New.Species <- table.sp$Species[1]
 New.Abbrev <- table.sp$Infraspecific.rank[1]
@@ -505,7 +509,8 @@ if (sum(table.sp$Taxonomic.status.in.TPL=="Accepted")==0 && sum(table.sp$Taxonom
 Plant.Name.Index <- TRUE
 Taxonomic.status <- "Unresolved"
 Family <- table.sp$Family[1]
-New.Genus <- table.sp$Genus[1]
+New.Genus <- if('' %in% table.sp$Genus.hybrid.marker) {table.sp$Genus[1]} else {
+  paste(table.sp$Genus.hybrid.marker[1], table.sp$Genus[1], sep='')}
 New.Hybrid.marker <- table.sp$Species.hybrid.marker[1]
 New.Species <- table.sp$Species[1]
 New.Abbrev <- table.sp$Infraspecific.rank[1]

--- a/R/TPLck.R
+++ b/R/TPLck.R
@@ -73,10 +73,11 @@ notfound <- function(id, Genus, Species, Abbrev, Infraspecific, version,
   Family <- ""
   Taxonomic.status <- ""
   Plant.Name.Index <- FALSE
-  New.Genus <- Genus
-  New.Species <- Species
-  New.Abbrev <- Abbrev
-  New.Infraspecific <- Infraspecific
+  #If no match found, returns NA for new genus and species to avoid confusion
+  New.Genus <- NA
+  New.Species <- NA
+  New.Abbrev <- ''
+  New.Infraspecific <- ''
   Authority <- ""
   Typo <- FALSE
   WFormat <- FALSE

--- a/R/TPLck.R
+++ b/R/TPLck.R
@@ -1,13 +1,33 @@
-TPLck <-
-function(sp, corr=TRUE, diffchar=2, max.distance=1, infra=TRUE, abbrev=TRUE, version="1.1", encoding="UTF-8") {
-sp <- as.character(sp)
+TPLck <- function(sp, id=NULL, corr=TRUE, diffchar=2, max.distance=1, infra=TRUE, abbrev=TRUE, version="1.1", encoding="UTF-8") {
 
+  ## Format Species Name ##
+
+  sp <- as.character(sp)
 abbr <- NA
+
+#Remove infraspecific abbrev from species name, add stdz abbrev to final output
 if(abbrev==TRUE) {
-vec0 <- c("nothossp. ", "nothossp.", " nothossp ", "nothosubsp. ", "nothosubsp.", " nothosubsp ", "cultivar. ", "cultivar.", " cultivar ", "subfo. ", " subfo ", "subf. ", "subf.", " subf ", " subproles ", "cf. ", "cf.", " cf ", "aff. ", "aff.", " aff ", "s.l. ", "s.l.", "s.l ", "s.str. ", "s.str.", "s.str ", "\u00D7", "x. ", "x.", " x ", "X. ", "X.", " X ", "X ", "f. ", "f.", " f ", "fo. ", "fo.", " fo ", " forma ", "subvar.", " subvar ", "var. ", "var.", " var ", "subsp. ", "subsp.", " subsp ", "ssp. ", "ssp.", " ssp ", " gama ", " grex ", "lus. ", "lus.", " lus ", " lusus ", "monstr. ", " monstr ", "nm. ", "nm.", " nm ", "prol. ", "prol.", " prol ", " proles ", " race ", "subvar. ", "cv. ", "cv.", " cv ")
+  vec0 <- c("nothossp. ", "nothossp.", " nothossp ", "nothosubsp. ",
+            "nothosubsp.", " nothosubsp ", "cultivar. ", "cultivar.",
+            " cultivar ", "cv. ", "cv."," cv ", "subfo. ", " subfo ", "subf. ", "subf.",
+            " subf ", " subproles ", "cf. ", "cf.", " cf ", "aff. ",
+            "aff.", " aff ", "s.l. ", "s.l.", "s.l ", "s.str. ",
+            "s.str.", "s.str ", "×", "x. ", "x.", " x ", "X. ",
+            "X.", " X ", "X ", "f. ", "f.", " f ", "fo. ", "fo.",
+            " fo ", " forma ", "subvar.", " subvar ", "subvar. ", "var. ",
+            "var.", " var ", "subsp. ", "subsp.", " subsp ",
+            "ssp. ", "ssp.", " ssp ", " gama ", " grex ", "lus. ",
+            "lus.", " lus ", " lusus ", "monstr. ", " monstr ",
+            "nm. ", "nm.", " nm ", "prol. ", "prol.", " prol ",
+            " proles ", " race ")
+  vec1 <- c(rep('nothosubsp.', 6), rep('cv.', 6), rep('subf.',5), "subproles",
+            rep('cf.', 3), rep("aff.",3), rep('s.l.', 3), rep("s.str.", 3), rep("×",8),
+            rep("f.",7), rep("subvar.",3), rep("var.",3), rep('subsp.',6)," gama ",
+            " grex ", rep("lus.",4), rep("monstr.",2), rep("nm.",3), rep("prol.",4),
+            " race ") #Standardize abbrev
 
 for(j in 1:length(vec0)) {
-abbr <- ifelse(length(grep(vec0[j], sp, fixed=TRUE))>0, vec0[j], abbr)
+abbr <- ifelse(length(grep(vec0[j], sp, fixed=TRUE))>0, vec1[j], abbr)
 sp <- sub(vec0[j], " ", sp, fixed=TRUE)
 }
 abbr <- gsub(" ", "", abbr, fixed=TRUE)
@@ -21,85 +41,220 @@ sp <- ifelse(substr(sp, 1, 1)==" ", substr(sp, 2, nchar(sp)), sp)
 }
 Abbrev <- abbr
 
+#Format name for TPL
 genus <- unlist(strsplit(sp," "))[1]
 species <- unlist(strsplit(sp," "))[2]
 if(corr==TRUE) {species <- tolower(species)}
 infrasp <- ifelse(length(unlist(strsplit(sp," "))) > 2, unlist(strsplit(sp," "))[3], "")
 if(corr==TRUE) {infrasp <- tolower(infrasp)}
+
+## Search TPL for Species Name ##
+
 vv <- ifelse(version == "1.0", "", version)
 
 searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",genus,"+",species, "&csv=true", sep="")
 table.sp <- NULL
 try(table.sp <- read.csv(searchstring, header=TRUE, sep=",", fill=TRUE, colClasses="character", as.is = TRUE, encoding=encoding),silent=TRUE)
+
+#Set up fields
 Genus <- genus
 Species <- species
 Infraspecific <- infrasp
 New.Hybrid.marker <- ""
 marker <- FALSE
 marker.infra <- FALSE
+Multi <- FALSE #to mark if multiple valid names/synonyms are returned
 
-# Loop 1
+
+## Function to fill in fields if species not found ##
+
+notfound <- function(id, Genus, Species, Abbrev, Infraspecific, version,
+                     New.Hybrid.marker){
+  Family <- ""
+  Taxonomic.status <- ""
+  Plant.Name.Index <- FALSE
+  New.Genus <- Genus
+  New.Species <- Species
+  New.Abbrev <- Abbrev
+  New.Infraspecific <- Infraspecific
+  Authority <- ""
+  Typo <- FALSE
+  WFormat <- FALSE
+  ID <- ""
+  New.ID <- ""
+  if(is.null(id)){
+    return(data.frame(Genus, Species, Abbrev, Infraspecific,
+                      ID, Plant.Name.Index, TPL_version = version, Taxonomic.status,
+                      Family, New.Genus, New.Hybrid.marker, New.Species, New.Abbrev,
+                      New.Infraspecific, Authority, New.ID, Typo, Multi, WFormat,
+                      stringsAsFactors = FALSE))
+  } else {
+    return(data.frame(UserID = id, Genus, Species, Abbrev, Infraspecific,
+                      ID, Plant.Name.Index, TPL_version = version, Taxonomic.status,
+                      Family, New.Genus, New.Hybrid.marker, New.Species, New.Abbrev,
+                      New.Infraspecific, Authority, New.ID, Typo, Multi, WFormat,
+                      stringsAsFactors = FALSE))
+  }
+}
+
+
+## If Nothing is Found ##
+
 if(is.null(table.sp)) {
-Family <- ""
-Taxonomic.status <- ""
-Plant.Name.Index <- FALSE
-New.Genus <- Genus
-New.Species <- Species
-New.Infraspecific <- Infraspecific
-Authority <- ""
-Typo <- FALSE
-WFormat <- TRUE
-ID <- ""
-New.ID <- ""
+  x <- notfound(id, Genus, Species, Abbrev, Infraspecific, version, New.Hybrid.marker)
+  x$WFormat <- T
+  return(x)
 } else
-# Loop 2
+
 if(!is.null(table.sp)) {
 k <- dim(table.sp)[2]
 z <- dim(table.sp)[1]
-# Loop 2.1
-if(k == 1) {
-Family <- ""
-Plant.Name.Index <- FALSE
-Taxonomic.status <- ""
-New.Genus <- Genus
-New.Species <- Species
-New.Infraspecific <- Infraspecific
-Authority <- ""
-Typo <- FALSE
-WFormat <- FALSE
-ID <- ""
-New.ID <- ""
-} else
-# Loop 2.2
-if(k > 1) {
-# Loop 2.2.1
-if(z == 0) {
-Family <- ""
-Plant.Name.Index <- FALSE
-Taxonomic.status <- ""
-New.Genus <- Genus
-New.Species <- Species
-New.Infraspecific <- Infraspecific
-Authority <- ""
-Typo <- FALSE
-WFormat <- FALSE
-ID <- ""
-New.ID <- ""
-} else
-# Loop 2.2.2
-if(z > 1) {
-# Loop 2.2.2.1
+
+if (k == 1|z == 0|all(is.na(table.sp$Taxonomic.status.in.TPL))) {
+  return(notfound(id, Genus, Species, Abbrev, Infraspecific, version,
+                  New.Hybrid.marker))
+}
+
+
+## If Multiple Entries Are Found ##
+
+else if (z > 0) {
+
+  ## If Matching to Genus Only ##
+
+  if(is.na(species)){
+    if('Accepted' %in% table.sp$Taxonomic.status.in.TPL){
+      table.sp <- table.sp[table.sp$Taxonomic.status.in.TPL=="Accepted",]
+      #Consider Genus valid, take first accepted species to assign family, etc.
+
+      Plant.Name.Index <- TRUE
+      Taxonomic.status <- table.sp$Taxonomic.status.in.TPL[1]
+      Family <- table.sp$Family[1]
+      New.Genus <- table.sp$Genus[1]
+      New.Hybrid.marker <- ''
+      New.Species <- ''
+      New.Abbrev <- ""
+      New.Infraspecific <- ""
+      Authority <- ''
+      Typo <- FALSE
+      WFormat <- FALSE
+      ID <- ''
+      New.ID <- ID
+
+    } else if('Synonym' %in% table.sp$Taxonomic.status.in.TPL){
+
+      #Find most common currently accepted genus, take family, etc from that
+
+      if('H' %in% table.sp$Confidence.level){
+        table.sp <- table.sp[table.sp$Confidence.level=="H",]
+      }
+
+      samp <- sample(1:nrow(table.sp), min(ceiling(0.25*nrow(table.sp)), 15))
+      newgen <- vector()
+
+      for(i in samp){
+        at <- readLines(paste("http://www.theplantlist.org/tpl",vv, "/record/",
+                              table.sp[i,1], sep = ""), encoding = encoding)
+        if (version == "1.1") {
+          az <- "<p>This name is a <a href=\"/1.1/about/#synonym\">synonym</a> of"
+        }
+        else if (version == "1.0") {
+          warning('Genus-level search not implemented for version 1.0')
+          return(notfound(id, Genus, Species, Abbrev, Infraspecific, version,
+                          New.Hybrid.marker))
+        }
+
+        syn <- at[pmatch(az, at)] #Looks for line that matches to current name
+        syn <- unlist(strsplit(unlist(strsplit(syn, split = ">")), "<"))
+        newgen[[i]] <- syn[13]
+      }
+
+      newgen <- newgen[samp]
+
+      if(length(unique(newgen))>1) {
+        warning(paste('Multiple possible synonyms for',genus))
+        Multi <- TRUE
+        freq <- vector()
+
+        for(i in 1:length(unique(newgen))) {
+          freq[i] <- length(newgen[newgen==unique(newgen)[i]])
+        }
+        ng <- unique(newgen)[which(freq==max(freq))] #Use the most frequent genus name
+      } else {
+        ng <- unique(newgen)
+      }
+
+      searchstring <- paste("http://www.theplantlist.org/tpl",vv,
+                            "/search?q=", ng,"&csv=true",sep = "")
+
+      #Search using updated genus name
+      try(table.sp <- read.table(searchstring, header =TRUE, sep = ",", fill =TRUE,
+                                 colClasses = "character", as.is = TRUE,
+                                 encoding = encoding), silent = TRUE)
+
+      #Keep only accepted, high-quality names if there's a choice
+      if(nrow(table.sp)>1){
+        if('Accepted' %in% table.sp$Taxonomic.status.in.TPL) {
+          table.sp <- table.sp[table.sp$Taxonomic.status.in.TPL=="Accepted",]
+        }
+        if ('H' %in% table.sp$Confidence.level) {
+          table.sp <- table.sp[table.sp$Confidence.level=='H',]
+        } else if ('M' %in% table.sp$Confidence.level) {
+          table.sp <- table.sp[table.sp$Confidence.level=='M',]
+        }
+      }
+
+      Plant.Name.Index <- TRUE
+      Taxonomic.status <- 'Synonym'
+      Family <- table.sp$Family[1]
+      New.Genus <- ng
+      New.Hybrid.marker <- ''
+      New.Species <- ''
+      New.Abbrev <- ""
+      New.Infraspecific <- ""
+      Authority <- ''
+      Typo <- FALSE
+      WFormat <- FALSE
+      ID <- ''
+      New.ID <- ID
+    } else { #If all names are listed as unresolved or misapplied, return as not found
+      return(notfound(id, Genus, Species, Abbrev, Infraspecific, version,
+                      New.Hybrid.marker))
+    }
+
+    if(is.null(id)){
+      return(data.frame(Genus, Species, Abbrev, Infraspecific,
+                        ID, Plant.Name.Index, TPL_version = version, Taxonomic.status,
+                        Family, New.Genus, New.Hybrid.marker, New.Species, New.Abbrev,
+                        New.Infraspecific, Authority, New.ID, Typo, Multi, WFormat,
+                        stringsAsFactors = FALSE))
+    } else {
+      return(data.frame(UserID = id, Genus, Species, Abbrev, Infraspecific,
+                        ID, Plant.Name.Index, TPL_version = version, Taxonomic.status,
+                        Family, New.Genus, New.Hybrid.marker, New.Species, New.Abbrev,
+                        New.Infraspecific, Authority, New.ID, Typo, Multi, WFormat,
+                        stringsAsFactors = FALSE))
+    }
+  }
+
+  ## If Doing Fuzzy Matching ##
+
 if (length(unique(paste(table.sp$Genus, table.sp$Species))) > 1 && corr==TRUE) {
 spx <- length(agrep(species, "sp", max.distance=0)) + length(agrep(species, "sp.", max.distance=0))
 mf <- c(as.character(1:1000))
 is.mf <- agrep(species, mf, max.distance=list(deletions=1), value=TRUE)
+#Run fuzzy match w/ set max distance between given and matched sp epithet
 cck <- agrep(species, table.sp$Species, value=TRUE, max.distance=max.distance)
 ddf <- abs(nchar(cck) - nchar(species))
 if(length(cck) > 0) {
 cck <- cck[ddf==min(ddf)]
+#If mult matches, select smallest diff in number of char from original
 ddf <- abs(nchar(cck) - nchar(species))
 }
 levs <- length(unique(cck))
+
+## Search for Best Fuzzy Match ##
+
 if(length(is.mf) == 0 && length(cck) > 0 && ddf <= diffchar && levs == 1 && spx == 0) {
 searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",genus,"+",cck[1], "&csv=true", sep="")
 try(table.sp <- read.table(searchstring, header=TRUE, sep=",", fill=TRUE,colClasses = "character", as.is = TRUE, encoding=encoding), silent=T)
@@ -108,24 +263,20 @@ z <- dim(table.sp)[1]
 marker <- TRUE
 }
 }
-# Loop 2.2.2.2
+
 if (length(unique(paste(table.sp$Genus, table.sp$Species))) > 1) {
-Family <- ""
-Plant.Name.Index <- FALSE
-Taxonomic.status <- ""
-New.Genus <- Genus
-New.Species <- Species
-New.Infraspecific <- Infraspecific
-Authority <- ""
-Typo <- FALSE
-WFormat <- FALSE
-ID <- ""
-New.ID <- ""
+  return(notfound(id, Genus, Species, Abbrev, Infraspecific, version,
+                  New.Hybrid.marker))
+  #If still returning entire genus list, or corr=F, match was not found
+  #   could potentially alter code here to search for 2nd best match?
 }
-# Loop 2.2.2.3
+
 if (length(unique(paste(table.sp$Genus, table.sp$Species))) == 1) {
 grep1 <- grep(infrasp, table.sp$Infraspecific.epithet, value=TRUE)
 ngrep <- nchar(grep1)
+
+## If no Appropriate Infrasp Match, Fuzzy Match Infra Names ##
+
 if ((length(ngrep) == 0 || abs(ngrep-nchar(infrasp)) > 0) && corr==TRUE && !is.na(infrasp) && nchar(infrasp)>0) {
 cck.infra <- agrep(infrasp, table.sp$Infraspecific.epithet, value=TRUE, max.distance=max.distance)
 ddf.infra <- abs(nchar(cck.infra) - nchar(infrasp))
@@ -141,46 +292,56 @@ ngrep <- nchar(grep1)
 marker.infra <- TRUE
 }
 }
-# Loop 2.2.2.3.A
-if (infra==TRUE && length(grep(infrasp, table.sp$Infraspecific.epithet))>0 && abs(ngrep-(nchar(infrasp)))==0) {
+
+  #Match to Infrasp Name w/ same # of char
+  if (infra==TRUE && length(grep(infrasp, table.sp$Infraspecific.epithet))>0 && abs(ngrep-(nchar(infrasp)))==0) {
 table.sp <- table.sp[table.sp$Infraspecific.epithet==infrasp,]
-#table.sp$Taxonomic.status.in.TPL <- table.sp$Taxonomic.status.in.TPL
 if (dim(table.sp)[1]>1 && sum(!is.na(grep(Abbrev, table.sp$Infraspecific.rank, ignore.case=TRUE)))>0) {
 table.sp <- table.sp[table.sp$Infraspecific.rank==Abbrev,]
 }
 } else
-# Loop 2.2.2.3.B
+
 if (infra==FALSE || length(grep(infrasp, table.sp$Infraspecific.epithet))==0 || abs(ngrep-(nchar(infrasp)))>0) {
-# Loop 2.2.2.3.B.1
-if((table.sp$Infraspecific.epithet=="" || is.na(table.sp$Infraspecific.epithet))==FALSE && length(grep(Species, table.sp$Infraspecific.epithet))==0) {
-table.sp <- table.sp[table.sp$Infraspecific.epithet=="" || is.na(table.sp$Infraspecific.epithet),]
-table.sp$Taxonomic.status.in.TPL <- table.sp$Taxonomic.status.in.TPL
+
+#Or match to infrasp name w/ NA or blank
+if(table.sp$Infraspecific.epithet %in% c("", NA) && length(grep(Species, table.sp$Infraspecific.epithet))==0) {
+table.sp <- table.sp[table.sp$Infraspecific.epithet %in% c("", NA),]
 } else
-# Loop 2.2.2.3.B.2
-if((table.sp$Infraspecific.epithet=="" || is.na(table.sp$Infraspecific.epithet))==FALSE && length(grep(Species, table.sp$Infraspecific.epithet))>0) {
+
+  #Or match to infrasp name = original species epithet
+if(!table.sp$Infraspecific.epithet %in% c("", NA) && length(grep(Species, table.sp$Infraspecific.epithet))>0) {
 table.sp <- table.sp[table.sp$Infraspecific.epithet==Species, ]
-table.sp$Taxonomic.status.in.TPL <- table.sp$Taxonomic.status.in.TPL
 }
 }
+#Update k and z (now that table.sp has been reduced)
 k <- dim(table.sp)[2]
 z <- dim(table.sp)[1]
-# Loop 2.2.2.3.1
+
+
+## Evaluate New Species Table to Choose Best Match ##
+
 if (z == 0) {
-Family <- ""
-Plant.Name.Index <- FALSE
-Taxonomic.status <- ""
-New.Genus <- Genus
-New.Species <- Species
-New.Infraspecific <- Infraspecific
-Authority <- ""
-Typo <- ifelse(marker==TRUE || marker.infra==TRUE, TRUE, FALSE)
-WFormat <- FALSE
-ID <- ""
-New.ID <- ""
-} else
-# Loop 2.2.2.3.2 (Search for accepted names)
-if (any(table.sp$Taxonomic.status.in.TPL=="Accepted")) {
+  #Nothing was a sufficiently good match, return 'no match'
+  return(notfound(id, Genus, Species, Abbrev, Infraspecific, version,
+                  New.Hybrid.marker))
+}
+
+#If any name is listed as "Accepted"  or High/Med Quality, Use that name
+#   (uses 1st "Accepted" Name listed)
+else if (any(table.sp$Taxonomic.status.in.TPL=="Accepted")) {
 table.sp <- table.sp[table.sp$Taxonomic.status.in.TPL=="Accepted", ]
+if(nrow(table.sp)>1){
+  if (sum(table.sp$Confidence.level == "H") > 0) {
+    table.sp <- table.sp[table.sp$Confidence.level == "H", ]
+  }
+  else if (sum(table.sp$Confidence.level == "M") > 0) {
+    table.sp <- table.sp[table.sp$Confidence.level == "M", ]
+  }
+  if (nrow(table.sp) > 1) {
+    warning(paste(sp, "has more than one valid accepted name"))
+    Multi <- TRUE
+  }
+}
 Plant.Name.Index <- TRUE
 Taxonomic.status <- table.sp$Taxonomic.status.in.TPL[1]
 Family <- table.sp$Family[1]
@@ -188,10 +349,12 @@ New.Genus <- table.sp$Genus[1]
 New.Hybrid.marker <- table.sp$Species.hybrid.marker[1]
 New.Species <- table.sp$Species[1]
 if (infra == T && length(grep(infrasp, table.sp$Infraspecific.epithet))>0) {
-New.Infraspecific <- table.sp$Infraspecific.epithet[1]
+  New.Abbrev <- table.sp$Infraspecific.rank[1]
+  New.Infraspecific <- table.sp$Infraspecific.epithet[1]
 } else
 if (infra == F || length(grep(infrasp, table.sp$Infraspecific.epithet))==0) {
-New.Infraspecific <- ""
+  New.Abbrev <- ""
+  New.Infraspecific <- ""
 }
 Authority <- table.sp$Authorship[1]
 Typo <- ifelse(marker==TRUE || marker.infra==TRUE, TRUE, FALSE)
@@ -199,7 +362,7 @@ WFormat <- FALSE
 ID <- table.sp[1,1]
 New.ID <- ID
 } else
-# Loop 2.2.2.3.3 (Search for synonyms or missapplied names)
+# (Search for synonyms or missapplied names)
 if (sum(table.sp$Taxonomic.status.in.TPL=="Accepted")==0 && (sum(table.sp$Taxonomic.status.in.TPL=="Synonym")>0||sum(table.sp$Taxonomic.status.in.TPL=="Misapplied")>0)) {
 if(sum(table.sp$Taxonomic.status.in.TPL=="Synonym")>0) {
 table.sp <- table.sp[table.sp$Taxonomic.status.in.TPL=="Synonym", ]
@@ -215,7 +378,18 @@ table.sp <- table.sp[table.sp$Confidence.level=="M", ]
 }
 if(nrow(table.sp)>1) {
 warning(paste(sp, "has more than one valid synonym"))
+Multi <- TRUE
 }
+
+if (sum(table.sp$Taxonomic.status.in.TPL == "Synonym") > 0) {
+  Taxonomic.status <- "Synonym"
+}
+else if (sum(table.sp$Taxonomic.status.in.TPL == "Misapplied") > 0) {
+  Taxonomic.status <- "Misapplied"
+}
+
+## Search for Updated Name of Synonyms in Text ##
+
 table.sp.id <- table.sp[1,1]
 ID <- table.sp.id
 at <- readLines(paste("http://www.theplantlist.org/tpl", vv, "/record/", table.sp.id, sep=""), encoding=encoding)
@@ -226,73 +400,85 @@ az <- "<p>This name is a <a href=\"/1.1/about/#synonym\">synonym</a> of"
 if (version=="1.0") {
 az <- "<p>This name is a <a href=\"/about/#synonym\">synonym</a> of"
 }
-} else 
+} else
 if (sum(table.sp$Taxonomic.status.in.TPL=="Misapplied")>0) {
 if (version=="1.1") {
 az <- "<p>In the past this name has been <a href=\"/1.1/about/#misapplied\">erroneously used</a> to refer to"
-} else 
+} else
 if (version=="1.0") {
 az <- "<p>In the past this name has been <a href=\"/about/#misapplied\">erroneously used</a> to refer to"
 }
 }
-n <- pmatch(az, at)
+n <- pmatch(az, at) #Looks for line that matches to current name
 nsen <- at[n]
 nsen <- unlist(strsplit(unlist(strsplit(nsen, split=">")), "<"))
 if (version=="1.1") {
-searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[13],"+",ifelse(nsen[17]=="\u00D7", nsen[21], nsen[17]), "&csv=true", sep="")
+searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[13],"+",ifelse(nsen[17]=="×", nsen[21], nsen[17]), "&csv=true", sep="")
 } else
 if (version=="1.0") {
-searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[11],"+",ifelse(nsen[15]=="\u00D7", nsen[19], nsen[15]), "&csv=true", sep="")
+searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[11],"+",ifelse(nsen[15]=="×", nsen[19], nsen[15]), "&csv=true", sep="")
 }
 kup <- length(grep("var.", nsen)) + length(grep("subsp.", nsen))
 if(infra==T && kup > 0) {
 if (version=="1.1") {
-infrasp <- ifelse(nsen[17]=="\u00D7", nsen[29], nsen[25])
+infrasp <- ifelse(nsen[17]=="×", nsen[29], nsen[25])
 } else
 if (version=="1.0") {
-infrasp <- ifelse(nsen[15]=="\u00D7", nsen[27], nsen[23])
+infrasp <- ifelse(nsen[15]=="×", nsen[27], nsen[23])
 }
 } else
 if(kup == 0) {
 infrasp <- ""
 }
-if (sum(table.sp$Taxonomic.status.in.TPL=="Synonym")>0) {
-Taxonomic.status <- "Synonym"
-} else 
-if (sum(table.sp$Taxonomic.status.in.TPL=="Misapplied")>0) {
-Taxonomic.status <- "Misapplied"
-}
+
+
+## Find, Search by Updated Name (for Synonyms) ##
+
 try(table.sp <- read.table(searchstring, header=TRUE, sep=",", fill=TRUE, colClasses="character", as.is = TRUE, encoding=encoding),silent=TRUE)
-if (version=="1.1" && nsen[17]=="\u00D7") {
-table.sp <- table.sp[table.sp$Species.hybrid.marker=="\u00D7", ]
+if (version=="1.1" && nsen[17]=="×") {
+table.sp <- table.sp[table.sp$Species.hybrid.marker=="×", ]
 } else
-if (version=="1.0" && nsen[15]=="\u00D7") {
-table.sp <- table.sp[table.sp$Species.hybrid.marker=="\u00D7", ]
+if (version=="1.0" && nsen[15]=="×") {
+table.sp <- table.sp[table.sp$Species.hybrid.marker=="×", ]
 }
-grep1 <- grep(infrasp, table.sp$Infraspecific.epithet, value=TRUE)
-ngrep <- nchar(grep1)
-# Loop 2.2.2.3.3.A
-if (infra==TRUE && length(grep(infrasp, table.sp$Infraspecific.epithet))>0 && abs(ngrep-(nchar(infrasp)))==0) {
+
+if (infra == TRUE && any(table.sp$Infraspecific.epithet == infrasp)) {
 table.sp <- table.sp[table.sp$Infraspecific.epithet==infrasp,]
-table.sp$Taxonomic.status.in.TPL <- table.sp$Taxonomic.status.in.TPL
 } else
-# Loop 2.2.2.3.3.B
-if (infra==FALSE || length(grep(infrasp, table.sp$Infraspecific.epithet))==0 || abs(ngrep-(nchar(infrasp)))>0) {
-table.sp <- table.sp[table.sp$Infraspecific.epithet=="" || is.na(table.sp$Infraspecific.epithet),]
-table.sp$Taxonomic.status.in.TPL <- table.sp$Taxonomic.status.in.TPL
+
+if (infra == FALSE || all(table.sp$Infraspecific.epithet != infrasp)) {
+  table.sp <- table.sp[table.sp$Infraspecific.epithet %in% c('',NA),]
 }
+
+if(nrow(table.sp)>1){
+  if('Accepted' %in% table.sp$Taxonomic.status.in.TPL) {
+    table.sp <- table.sp[table.sp$Taxonomic.status.in.TPL=="Accepted",]
+  } else if ('H' %in% table.sp$Confidence.level) {
+    table.sp <- table.sp[table.sp$Confidence.level=='H',]
+  } else if ('M' %in% table.sp$Confidence.level) {
+    table.sp <- table.sp[table.sp$Confidence.level=='M',]
+  }
+
+  if(nrow(table.sp)>1){
+    warning(paste(sp, "has more than one valid updated name for synonym"))
+    Multi <- TRUE
+  }
+}
+
+#If still mutl entries, take first one
 Plant.Name.Index <- TRUE
 Family <- table.sp$Family[1]
 New.Genus <- table.sp$Genus[1]
 New.Hybrid.marker <- table.sp$Species.hybrid.marker[1]
 New.Species <- table.sp$Species[1]
+New.Abbrev <- table.sp$Infraspecific.rank[1]
 New.Infraspecific <- table.sp$Infraspecific.epithet[1]
 Authority <- table.sp$Authorship[1]
 Typo <- ifelse(marker==TRUE || marker.infra==TRUE, TRUE, FALSE)
 WFormat <- FALSE
 New.ID <- table.sp[1,1]
 } else
-# Loop 2.2.2.3.4 (Search for unresolved names)
+# (Search for unresolved names)
 if (sum(table.sp$Taxonomic.status.in.TPL=="Accepted")==0 && sum(table.sp$Taxonomic.status.in.TPL=="Synonym")==0 && sum(table.sp$Taxonomic.status.in.TPL=="Unresolved")>0) {
 Plant.Name.Index <- TRUE
 Taxonomic.status <- "Unresolved"
@@ -300,149 +486,34 @@ Family <- table.sp$Family[1]
 New.Genus <- table.sp$Genus[1]
 New.Hybrid.marker <- table.sp$Species.hybrid.marker[1]
 New.Species <- table.sp$Species[1]
+New.Abbrev <- table.sp$Infraspecific.rank[1]
 New.Infraspecific <- table.sp$Infraspecific.epithet[1]
 Authority <- table.sp$Authorship[1]
 Typo <- ifelse(marker==TRUE || marker.infra==TRUE, TRUE, FALSE)
 WFormat <- FALSE
 ID <- table.sp[1,1]
 New.ID <- ID
-}}} else
-# Loop 2.2.3
-if(z == 1) {
-# Loop 2.2.3.1
-if (is.na(table.sp$Taxonomic.status.in.TPL)) {
-Taxonomic.status <- ""
-Plant.Name.Index <- FALSE
-Family <- ""
-New.Genus <- Genus
-New.Species <- Species
-New.Infraspecific <- Infraspecific
-Authority <- ""
-Typo <- ifelse(marker==TRUE || marker.infra==TRUE, TRUE, FALSE)
-WFormat <- FALSE
-ID <- ""
-New.ID <- ""
-} else
-# Loop 2.2.3.2
-if (table.sp$Taxonomic.status.in.TPL=="Synonym"||table.sp$Taxonomic.status.in.TPL=="Misapplied") {
-ID <- table.sp[1,1]
-at <- readLines(paste("http://www.theplantlist.org/tpl", vv, "/search?q=", genus,"+", species, sep=""), encoding=encoding)
-if (table.sp$Taxonomic.status.in.TPL=="Synonym") {
-if (version=="1.1") {
-az <- "<p>This name is a <a href=\"/1.1/about/#synonym\">synonym</a> of"
-} else
-if (version=="1.0") {
-az <- "<p>This name is a <a href=\"/about/#synonym\">synonym</a> of"
-}
-} else 
-if (table.sp$Taxonomic.status.in.TPL=="Misapplied") {
-if (version=="1.1") {
-az <- "<p>In the past this name has been <a href=\"/1.1/about/#misapplied\">erroneously used</a> to refer to"
-} else 
-if (version=="1.0") {
-az <- "<p>In the past this name has been <a href=\"/about/#misapplied\">erroneously used</a> to refer to"
 }
 }
-n <- pmatch(az, at)
-nsen <- at[n]
-nsen <- unlist(strsplit(unlist(strsplit(nsen, split=">")), "<"))
-if (version=="1.1") {
-searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[13],"+",ifelse(nsen[17]=="\u00D7", nsen[21], nsen[17]), "&csv=true", sep="")
-} else
-if (version=="1.0") {
-searchstring <- paste("http://www.theplantlist.org/tpl", vv, "/search?q=",nsen[11],"+",ifelse(nsen[15]=="\u00D7", nsen[19], nsen[15]), "&csv=true", sep="")
+if(is.null(id)){
+  results <- data.frame(Genus, Species, Abbrev, Infraspecific,
+                        ID, Plant.Name.Index, TPL_version = version,
+                        Taxonomic.status, Family, New.Genus, New.Hybrid.marker,
+                        New.Species, New.Abbrev, New.Infraspecific, Authority,
+                        New.ID, Typo, Multi, WFormat, stringsAsFactors = FALSE)
+
+} else {
+  UserID <- id
+  results <- data.frame(UserID, Genus, Species, Abbrev, Infraspecific,
+                        ID, Plant.Name.Index, TPL_version = version,
+                        Taxonomic.status, Family, New.Genus, New.Hybrid.marker,
+                        New.Species, New.Abbrev, New.Infraspecific, Authority,
+                        New.ID, Typo, Multi, WFormat, stringsAsFactors = FALSE)
+
 }
-kup <- length(grep("var.", nsen)) + length(grep("subsp.", nsen))
-if(infra==T && kup > 0) {
-if (version=="1.1") {
-infrasp <- ifelse(nsen[17]=="\u00D7", nsen[29], nsen[25])
-} else
-if (version=="1.0") {
-infrasp <- ifelse(nsen[15]=="\u00D7", nsen[27], nsen[23])
+return(results)
+
 }
-} else
-if(kup == 0) {
-infrasp <- ""
+
 }
-if (table.sp$Taxonomic.status.in.TPL=="Synonym") {
-Taxonomic.status <- "Synonym"
-} else 
-if (table.sp$Taxonomic.status.in.TPL=="Misapplied") {
-Taxonomic.status <- "Misapplied"
-}
-try(table.sp <- read.table(searchstring, header=TRUE, sep=",", fill=TRUE, colClasses="character", encoding=encoding),silent=TRUE)
-if (version=="1.1" && nsen[17]=="\u00D7") {
-table.sp <- table.sp[table.sp$Species.hybrid.marker=="\u00D7", ]
-New.Hybrid.marker <- "\u00D7"
-} else
-if (version=="1.0" && nsen[15]=="\u00D7") {
-table.sp <- table.sp[table.sp$Species.hybrid.marker=="\u00D7", ]
-New.Hybrid.marker <- "\u00D7"
-}
-Plant.Name.Index <- TRUE
-Family <- table.sp$Family[1]
-if (version=="1.1") {
-New.Genus <- nsen[13]
-New.Species <- ifelse(nsen[17]=="\u00D7", nsen[21], nsen[17])
-Authority <- ifelse(nsen[17]=="\u00D7", nsen[25], nsen[21])
-} else
-if (version=="1.0") {
-New.Genus <- nsen[11]
-New.Species <- ifelse(nsen[15]=="\u00D7", nsen[19], nsen[15])
-Authority <- ifelse(nsen[15]=="\u00D7", nsen[23], nsen[19])
-}
-grep1 <- grep(infrasp, table.sp$Infraspecific.epithet, value=TRUE)
-ngrep <- nchar(grep1)
-if (length(ngrep) == 0 && corr==TRUE && !is.na(infrasp) && nchar(infrasp)>0) {
-cck.infra <- agrep(infrasp, table.sp$Infraspecific.epithet, value=TRUE, max.distance=max.distance)
-ddf.infra <- abs(nchar(cck.infra) - nchar(infrasp))
-if(length(cck.infra) > 0) {
-cck.infra <- cck.infra[ddf.infra==min(ddf.infra)]
-ddf.infra <- abs(nchar(cck.infra) - nchar(infrasp))
-}
-levs <- length(unique(cck.infra))
-if(length(cck.infra) > 0 && ddf.infra <= diffchar && levs == 1) {
-infrasp <- cck.infra
-grep1 <- grep(infrasp, table.sp$Infraspecific.epithet, value=TRUE)
-ngrep <- nchar(grep1)
-marker.infra <- TRUE
-}
-}
-# Loop 2.2.2.3.3.A
-if (infra==TRUE && length(grep(infrasp, table.sp$Infraspecific.epithet))>0 && abs(ngrep-(nchar(infrasp)))==0) {
-table.sp <- table.sp[table.sp$Infraspecific.epithet==infrasp,]
-table.sp$Taxonomic.status.in.TPL <- table.sp$Taxonomic.status.in.TPL
-if (dim(table.sp)[1]>1 && sum(!is.na(grep(Abbrev, table.sp$Infraspecific.rank, ignore.case=TRUE)))>0) {
-table.sp <- table.sp[table.sp$Infraspecific.rank==Abbrev,]
-}
-} else
-# Loop 2.2.2.3.3.B
-if (infra==FALSE || length(grep(infrasp, table.sp$Infraspecific.epithet))==0 || abs(ngrep-(nchar(infrasp)))>0) {
-table.sp <- table.sp[table.sp$Infraspecific.epithet=="" || is.na(table.sp$Infraspecific.epithet),]
-table.sp$Taxonomic.status.in.TPL <- table.sp$Taxonomic.status.in.TPL
-}
-New.Infraspecific <- table.sp$Infraspecific.epithet[1]
-Typo <- ifelse(marker==TRUE || marker.infra==TRUE, TRUE, FALSE)
-WFormat <- FALSE
-New.ID <- table.sp[1,1]
-} else
-# Loop 2.2.3.3
-if (table.sp$Taxonomic.status.in.TPL=="Accepted"||table.sp$Taxonomic.status.in.TPL=="Unresolved") {
-Plant.Name.Index <- TRUE
-Taxonomic.status <- table.sp$Taxonomic.status.in.TPL[1]
-Family <- table.sp$Family
-New.Genus <- table.sp$Genus
-New.Hybrid.marker <- table.sp$Species.hybrid.marker[1]
-New.Species <- table.sp$Species
-New.Infraspecific <- table.sp$Infraspecific.epithet
-Authority <- table.sp$Authorship
-Typo <- ifelse(marker==TRUE || marker.infra==TRUE, TRUE, FALSE)
-WFormat <- FALSE
-ID <- table.sp[1,1]
-New.ID <- ID
-}
-} # End of loop 2.2.3
-} # End of loop 2.1
-} # End of loop 2
-results <- data.frame(Genus, Species, Abbrev, Infraspecific, ID, Plant.Name.Index, TPL_version=version, Taxonomic.status, Family, New.Genus, New.Hybrid.marker, New.Species, New.Infraspecific, Authority, New.ID, Typo, WFormat, stringsAsFactors = FALSE)
 }


### PR DESCRIPTION
This code is modified from TPLck and TPL in the package Taxonstand (version 1.7):
~ Added an optional user-defined ID column for easy matching between output and an original data file
~ Standardizes infraspecific taxonomic abbreviations in the input species list
~ Forces output to print to screen if not assigned to an object
~ Corrects a bug that returned infraspecific categories under the "Authority" column when a species matched to a single entry in the plant list (e.g. Isolepis platycarpa)
~ Corrects an error when infra=F or infraspecific name could not be matched
~ When multiple specific or infraspecific names are matched using fuzzy matching with max.distance > 1, looks for names that match with max.distance=1 and uses those preferentially (e.g. Prunus persica var. nectarine or Iris louisiana)
~ Adds warning if fuzzy matching returns more than one possible name, continues with first name returned
~ When TPL only has one species match for a genus, that match is automatically returned even if it doesn't match the specific epithet. That return is now rejected as unmatched (e.g. Lophozonia menziesii)
~ When fuzzy matching infraspecific epithets, rejects matches with a difference in character number greater than diffchar (e.g. Polygonum aviculare agg.)
~ Adds a new infraspecific abbreviation when a species is matched at the infraspecific level (e.g. Pinus pityusa)
~ When queried name is a synonym and accepted name is queried, selects best match of the second query
~ When multiple accepted or synonym names are returned, in addition to printing a warning, it is now also indicated in returned data.frame as Multi=TRUE
~ Code now accommodates hybrid genera in TPL version 1.1 (e.g. Agropogon littoralis)
